### PR TITLE
Add support for skipping headings

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function toc(options) {
   var heading = settings.heading || defaultHeading
   var depth = settings.maxDepth || 6
   var tight = settings.tight
+  var skip = settings.skip
 
   return transformer
 
@@ -18,7 +19,8 @@ function toc(options) {
     var result = util(node, {
       heading: heading,
       maxDepth: depth,
-      tight: tight
+      tight: tight,
+      skip: skip
     })
 
     if (result.index === null || result.index === -1 || !result.map) {

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,12 @@ are included (those with three hashes, `###`).
 
 `boolean?`, default: `false` — Whether to compile list-items tightly.
 
+##### `options.skip`
+
+`string?` — Headings to skip, wrapped in `new RegExp('^(' + value + ')$', 'i')`.
+Any heading matching this expression will not be present in the table of
+contents.
+
 ## Related
 
 *   [`remark-slug`][slug]

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ are included (those with three hashes, `###`).
 
 `boolean?`, default: `false` — Whether to compile list-items tightly.
 
-##### `options.skip`
+###### `options.skip`
 
 `string?` — Headings to skip, wrapped in `new RegExp('^(' + value + ')$', 'i')`.
 Any heading matching this expression will not be present in the table of

--- a/test/fixtures/skip/config.json
+++ b/test/fixtures/skip/config.json
@@ -1,0 +1,3 @@
+{
+  "skip": "example|notes?"
+}

--- a/test/fixtures/skip/input.md
+++ b/test/fixtures/skip/input.md
@@ -1,0 +1,27 @@
+# Normal
+
+## Table of Contents
+
+## Alpha
+
+## Bravo
+
+### Example
+
+### Note
+
+## Charlie
+
+### Note
+
+## Delta
+
+### Examples
+
+## Echo
+
+### Notes
+
+## Foxtrot
+
+## Example

--- a/test/fixtures/skip/output.md
+++ b/test/fixtures/skip/output.md
@@ -1,0 +1,41 @@
+# Normal
+
+## Table of Contents
+
+-   [Alpha](#alpha)
+
+-   [Bravo](#bravo)
+
+-   [Charlie](#charlie)
+
+-   [Delta](#delta)
+
+    -   [Examples](#examples)
+
+-   [Echo](#echo)
+
+-   [Foxtrot](#foxtrot)
+
+## Alpha
+
+## Bravo
+
+### Example
+
+### Note
+
+## Charlie
+
+### Note
+
+## Delta
+
+### Examples
+
+## Echo
+
+### Notes
+
+## Foxtrot
+
+## Example

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var test = require('tape')
 var fs = require('fs')
 var path = require('path')
+var test = require('tape')
 var remark = require('remark')
 var negate = require('negate')
 var hidden = require('is-hidden')


### PR DESCRIPTION
Adds the new `skip` option from https://github.com/syntax-tree/mdast-util-toc/pull/61

Fixes #22
